### PR TITLE
update the context to match the published dcc version

### DIFF
--- a/src/contexts/dcc-v1.json
+++ b/src/contexts/dcc-v1.json
@@ -28,12 +28,15 @@
     "image": { "@id": "schema:image", "@type": "@id" },
 
     "awardedOnCompletionOf": { "@reverse": "schema:educationalCredentialAwarded" },
-
+    "competencyRequired": "schema:EducationalOccupationalCredential#competencyRequired",
+    "credentialCategory": "schema:EducationalOccupationalCredential#credentialCategory",
     "hasCredential": "schema:hasCredential",
+    "assertion": "dcc:assertion",
     "Issuer": "obi:Issuer",
 
     "ProgramCompletionCredential": "dcc:ProgramCompletionCredential",
     "CourseCompletionCredential": "dcc:CourseCompletionCredential",
-    "LearningCredential": "dcc:LearningCredential"
+    "LearningCredential": "dcc:LearningCredential",
+    "Assertion": "dcc:Assertion"
   }
 }


### PR DESCRIPTION
The published dcc context has some new fields that aren't reflected here, so we're unable to sign anything that uses those fields at the moment.